### PR TITLE
Add oscap-anaconda-addon builds to Jenkins

### DIFF
--- a/ansible/jobs/oscap-anaconda-addon-master.xml
+++ b/ansible/jobs/oscap-anaconda-addon-master.xml
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>100</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.19.2">
+      <projectUrl>https://github.com/OpenSCAP/oscap-anaconda-addon/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <org.bstick12.jenkinsci.plugins.leastload.LeastLoadDisabledProperty plugin="leastload@1.0.3">
+      <leastLoadDisabled>false</leastLoadDisabled>
+    </org.bstick12.jenkinsci.plugins.leastload.LeastLoadDisabledProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.5.0">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>https://github.com/OpenSCAP/oscap-anaconda-addon.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>*/master</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions/>
+  </scm>
+  <assignedNode>fedora</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.19.2">
+      <spec></spec>
+    </com.cloudbees.jenkins.GitHubPushTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+mkdir -p ~/rpmbuild/SOURCES
+make dist
+mv oscap-anaconda-addon-*.tar.gz ~/rpmbuild/SOURCES
+rpmbuild -ba oscap-anaconda-addon.spec</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.Mailer plugin="mailer@1.17">
+      <recipients>openscap-maint@redhat.com</recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/ansible/jobs/oscap-anaconda-addon-master.xml
+++ b/ansible/jobs/oscap-anaconda-addon-master.xml
@@ -51,6 +51,7 @@
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 mkdir -p ~/rpmbuild/SOURCES
+make po-pull
 make dist
 mv oscap-anaconda-addon-*.tar.gz ~/rpmbuild/SOURCES
 rpmbuild -ba oscap-anaconda-addon.spec</command>

--- a/ansible/jobs/oscap-anaconda-addon-rhel7.xml
+++ b/ansible/jobs/oscap-anaconda-addon-rhel7.xml
@@ -1,0 +1,71 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<project>
+  <actions/>
+  <description></description>
+  <keepDependencies>false</keepDependencies>
+  <properties>
+    <jenkins.model.BuildDiscarderProperty>
+      <strategy class="hudson.tasks.LogRotator">
+        <daysToKeep>-1</daysToKeep>
+        <numToKeep>100</numToKeep>
+        <artifactDaysToKeep>-1</artifactDaysToKeep>
+        <artifactNumToKeep>-1</artifactNumToKeep>
+      </strategy>
+    </jenkins.model.BuildDiscarderProperty>
+    <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.19.2">
+      <projectUrl>https://github.com/OpenSCAP/oscap-anaconda-addon/</projectUrl>
+      <displayName></displayName>
+    </com.coravy.hudson.plugins.github.GithubProjectProperty>
+    <org.bstick12.jenkinsci.plugins.leastload.LeastLoadDisabledProperty plugin="leastload@1.0.3">
+      <leastLoadDisabled>false</leastLoadDisabled>
+    </org.bstick12.jenkinsci.plugins.leastload.LeastLoadDisabledProperty>
+  </properties>
+  <scm class="hudson.plugins.git.GitSCM" plugin="git@2.5.0">
+    <configVersion>2</configVersion>
+    <userRemoteConfigs>
+      <hudson.plugins.git.UserRemoteConfig>
+        <url>https://github.com/OpenSCAP/oscap-anaconda-addon.git</url>
+      </hudson.plugins.git.UserRemoteConfig>
+    </userRemoteConfigs>
+    <branches>
+      <hudson.plugins.git.BranchSpec>
+        <name>*/rhel7-branch</name>
+      </hudson.plugins.git.BranchSpec>
+    </branches>
+    <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+    <submoduleCfg class="list"/>
+    <extensions/>
+  </scm>
+  <assignedNode>rhel7</assignedNode>
+  <canRoam>false</canRoam>
+  <disabled>false</disabled>
+  <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+  <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+  <triggers>
+    <com.cloudbees.jenkins.GitHubPushTrigger plugin="github@1.19.2">
+      <spec></spec>
+    </com.cloudbees.jenkins.GitHubPushTrigger>
+  </triggers>
+  <concurrentBuild>false</concurrentBuild>
+  <builders>
+    <hudson.tasks.Shell>
+      <command>#!/bin/bash
+mkdir -p ~/rpmbuild/SOURCES
+make dist
+mv oscap-anaconda-addon-*.tar.gz ~/rpmbuild/SOURCES
+rpmbuild -ba oscap-anaconda-addon.spec</command>
+    </hudson.tasks.Shell>
+  </builders>
+  <publishers>
+    <hudson.tasks.Mailer plugin="mailer@1.17">
+      <recipients>openscap-maint@redhat.com</recipients>
+      <dontNotifyEveryUnstableBuild>false</dontNotifyEveryUnstableBuild>
+      <sendToIndividuals>false</sendToIndividuals>
+    </hudson.tasks.Mailer>
+  </publishers>
+  <buildWrappers>
+    <hudson.plugins.ansicolor.AnsiColorBuildWrapper plugin="ansicolor@0.4.2">
+      <colorMapName>xterm</colorMapName>
+    </hudson.plugins.ansicolor.AnsiColorBuildWrapper>
+  </buildWrappers>
+</project>

--- a/ansible/jobs/oscap-anaconda-addon-rhel7.xml
+++ b/ansible/jobs/oscap-anaconda-addon-rhel7.xml
@@ -51,6 +51,7 @@
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 mkdir -p ~/rpmbuild/SOURCES
+make po-pull
 make dist
 mv oscap-anaconda-addon-*.tar.gz ~/rpmbuild/SOURCES
 rpmbuild -ba oscap-anaconda-addon.spec</command>

--- a/ansible/master.yml
+++ b/ansible/master.yml
@@ -32,6 +32,8 @@
       - openscap-master
       - openscap-parametrized
       - openscap-pull-requests
+      - oscap-anaconda-addon-master
+      - oscap-anaconda-addon-rhel7
       - scap-security-guide-nightly-oval510-zip
       - scap-security-guide-nightly-zip
       - scap-security-guide-nist-testsuite

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -144,7 +144,7 @@
       - python-cpio
       - zanata-python-client
       state: installed
-    when: ansible_distribution == 'RedHat' or ansible_distribution_version.split(".")[0] >= "7"
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] >= "7"
 
   - name: Ensure OpenSCAP Anaconda dependencies are installed (Fedora only)
     package:
@@ -153,6 +153,7 @@
       - python3-mock
       - python3-nose
       - python3-cpio
+      - python3-pycurl
       - python3-kickstart
       - zanata-python-client
       state: installed

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -142,6 +142,7 @@
       - python2-mock
       - python-nose
       - python-cpio
+      - zanata-python-client
       state: installed
     when: ansible_distribution == 'RedHat' or ansible_distribution_version.split(".")[0] >= "7"
 
@@ -153,6 +154,7 @@
       - python3-nose
       - python3-cpio
       - python3-kickstart
+      - zanata-python-client
       state: installed
     when: ansible_distribution == 'Fedora'
 

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -134,3 +134,25 @@
       - python3-gobject
       state: installed
     when: ansible_distribution == 'Fedora'
+
+  - name: Ensure OSCAP Anaconda dependencies are installed (RHEL7 only)
+    package:
+      name:
+      - anaconda
+      - python2-mock
+      - python-nose
+      - python-cpio
+      state: installed
+    when: ansible_distribution == 'RedHat' or ansible_distribution_version.split(".")[0] >= "7"
+
+  - name: Ensure OpenSCAP Anaconda dependencies are installed (Fedora only)
+    package:
+      name:
+      - anaconda
+      - python3-mock
+      - python3-nose
+      - python3-cpio
+      - python3-kickstart
+      state: installed
+    when: ansible_distribution == 'Fedora'
+


### PR DESCRIPTION
- Adding oscap-anaconda-addon rhel7 and master branch builds to jenkins to validate the builds and prevent the breaking of tests