### PR TITLE
Ctest support

### DIFF
--- a/ansible/all.yml
+++ b/ansible/all.yml
@@ -1,4 +1,4 @@
 ---
-- include: shared.yml
-- include: master.yml
-- include: workers.yml
+- include_playbook: shared.yml
+- include_playbook: master.yml
+- include_playbook: workers.yml

--- a/ansible/master.yml
+++ b/ansible/master.yml
@@ -84,18 +84,6 @@
       src: ./master_cfg/nginx.repo
       dest: /etc/yum.repos.d/nginx.repo
 
-# EPEL is needed for python-pip package, which is required for python-jenkins
-# and lxml -these are required by jenkins_job module. jenkins_job is required
-# by us.
-  - name: Add repository
-    yum_repository:
-      name: epel
-      description: Extra Packages for Enterprise Linux 7 - $basearch
-      mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
-      failovermethod: priority
-      gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7Server
-      gpgcheck: yes
-    when: ansible_distribution == 'RedHat'
 
   - name: Ensure dependencies are installed
     package:
@@ -104,7 +92,6 @@
       - libselinux-python
       - initscripts
       - java
-      - python-pip
       - git  # jenkins itself needs git as well
       state: installed
 

--- a/ansible/shared.yml
+++ b/ansible/shared.yml
@@ -18,6 +18,29 @@
     when: hostvars[item].ansible_default_ipv4.address is defined
     with_items: "{{ groups['all'] }}"
 
+  # EPEL is needed for python-pip package, which is required for python-jenkins
+  # and lxml -these are required by jenkins_job module. jenkins_job is required
+  # by us (on master). Also required for linkchecker (on workers)
+  - name: Add EPEL 7
+    yum_repository:
+      name: epel
+      description: Extra Packages for Enterprise Linux 7 - $basearch
+      mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch
+      failovermethod: priority
+      gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7Server
+      gpgcheck: yes
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
+
+  - name: Add EPEL 6
+    yum_repository:
+      name: epel
+      description: Extra Packages for Enterprise Linux 6 - $basearch
+      mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch
+      failovermethod: priority
+      gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6Server
+      gpgcheck: yes
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "6"
+
   # RHEL6 optional RPMs are required for yum-cron and -devel packages
   # we can't use yum_repository ansible module because it doesn't allow
   # modification of existing repo files, it's mainly for creating new files
@@ -43,6 +66,12 @@
       create: no
       state: present
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
+
+  - name: Install pip
+    package:
+      name:
+      - python-pip
+      state: installed
 
   - name: Install cronie
     package:

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -114,6 +114,13 @@
       - wget  # needed for the NIST test suite for SSG
       state: installed
 
+  # this is the only common way across rhel/fedora.
+  # It's url-based, because original project is dead, and fork is not established yet
+  - name: Ensure linkchecker is installed for SCAP Security Guide checking 
+    pip:
+      name:
+      - git+https://github.com/linkcheck/linkchecker.git
+
   - name: Ensure OpenSCAP Daemon dependencies are installed
     package:
       name:


### PR DESCRIPTION
With ctest enabled in SCAP Security Guide, we included `linkchecker`. It needs to be installed via pip.