### PR TITLE
Update test commands SSG jobs

### DIFF
--- a/ansible/jobs/scap-security-guide-nightly-oval510-zip.xml
+++ b/ansible/jobs/scap-security-guide-nightly-oval510-zip.xml
@@ -63,6 +63,13 @@
         </hudson.plugins.cmake.BuildToolStep>
       </toolSteps>
     </hudson.plugins.cmake.CmakeBuilder>
+    <hudson.plugins.cmake.CToolBuilder plugin="cmakebuilder@2.5.2">
+      <installationName>InSearchPath</installationName>
+      <workingDir>build</workingDir>
+      <toolArgs>-j 4
+--output-on-failure</toolArgs>
+      <toolId>ctest</toolId>
+    </hudson.plugins.cmake.CToolBuilder>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 mv build/zipfile/scap-security-guide-*.zip scap-security-guide-nightly-oval-510.zip

--- a/ansible/jobs/scap-security-guide-nightly-zip.xml
+++ b/ansible/jobs/scap-security-guide-nightly-zip.xml
@@ -62,6 +62,13 @@
         </hudson.plugins.cmake.BuildToolStep>
       </toolSteps>
     </hudson.plugins.cmake.CmakeBuilder>
+    <hudson.plugins.cmake.CToolBuilder plugin="cmakebuilder@2.5.2">
+      <installationName>InSearchPath</installationName>
+      <workingDir>build</workingDir>
+      <toolArgs>-j 4
+--output-on-failure</toolArgs>
+      <toolId>ctest</toolId>
+    </hudson.plugins.cmake.CToolBuilder>
     <hudson.tasks.Shell>
       <command>#!/bin/bash
 mv build/zipfile/scap-security-guide-*.zip scap-security-guide-nightly.zip</command>

--- a/ansible/jobs/scap-security-guide-pull-requests.xml
+++ b/ansible/jobs/scap-security-guide-pull-requests.xml
@@ -122,7 +122,8 @@
 
 cd build
 make -j $CPU_COUNT
-make -j $CPU_COUNT validate</command>
+# we don&apos;t want to check links for every PR
+CTEST_OUTPUT_ON_FAILURE=1 ctest -j $CPU_COUNT -E linkchecker </command>
     </hudson.tasks.Shell>
     <hudson.tasks.Shell>
       <command>#!/bin/bash


### PR DESCRIPTION
- Update test command in `scap-security-guide-pull-requests` job
  - This was already effective in jenkins, just updating ansible task.

- Add test command in nightly jobs
  - Example output of nightly run with ctest command: 
https://jenkins.open-scap.org/view/SCAP%20Security%20Guide/job/scap-security-guide-nightly-oval510-zip/292/console