### PR TITLE
Add pytest module for Fedora

### DIFF
--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -126,7 +126,8 @@
     package:
       name:
       - python2-jinja2  # needed for the new SSG yaml/jinja2 port
-      - python2-pytest  # needed for unit tests + coverage
+      - python2-pytest
+      - python3-pytest  # needed for unit tests + coverage
       state: installed
     when: ansible_distribution == 'Fedora'
 
@@ -149,7 +150,7 @@
     pip:
       name:
       - pytest
-    when: ansible_distribution == 'RedHat'
+      when: ansible_distribution == 'RedHat'
 
   - name: Ensure OpenSCAP Daemon dependencies are installed
     package:


### PR DESCRIPTION
So far it has been Python2-only, so add it for Python3, too.