### PR TITLE
Python3 support for Fedora.

### DIFF
--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -128,6 +128,8 @@
       - python2-jinja2  # needed for the new SSG yaml/jinja2 port
       - python2-pytest
       - python3-pytest  # needed for unit tests + coverage
+      - python3-jinja2
+      - python3-PyYAML
       state: installed
     when: ansible_distribution == 'Fedora'
 

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -126,7 +126,8 @@
     package:
       name:
       - python2-jinja2  # needed for the new SSG yaml/jinja2 port
-      - python2-pytest  # needed for unit tests + coverage
+      - python2-pytest
+      - python3-pytest  # needed for unit tests + coverage
       state: installed
     when: ansible_distribution == 'Fedora'
 


### PR DESCRIPTION
This is a resubmission of #47, includes installation of other packages needed for Python3 builds.
The aim is SSG Python3 support, which is a superset of OAA with pytest Python3 support.

Update: ~After discussing with @dahaic , it seems to us that it makes sense to have Fedora builds Python3-only. Therefore, it makes sense to remove as much of Python2 from the system as possible.
This way, it is much less likely that a build somehow using Python2 instead of Python3 completes without error.~ Unfortunately, it is not possible to remove Python2 modules we depend on without breaking the system.