### PR TITLE
Re add rhel6 node

### DIFF
--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,6 +1,9 @@
 [master]
 jenkins-master ansible_host=13.58.12.8 ansible_user=ec2-user
 
+[worker_rhel6]
+jenkins-worker-rhel6-1 ansible_host=13.59.134.161 ansible_user=ec2-user
+
 [worker_rhel7]
 jenkins-worker-rhel7-1 ansible_host=13.58.232.157 ansible_user=ec2-user
 

--- a/ansible/shared.yml
+++ b/ansible/shared.yml
@@ -31,6 +31,29 @@
       gpgcheck: yes
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
 
+  - name: Add EPEL 6
+    yum_repository:
+      name: epel
+      description: Extra Packages for Enterprise Linux 6 - $basearch
+      mirrorlist: https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch
+      failovermethod: priority
+      gpgkey: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-6Server
+      gpgcheck: yes
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "6"
+
+  # RHEL6 optional RPMs are required for yum-cron and -devel packages
+  # we can't use yum_repository ansible module because it doesn't allow
+  # modification of existing repo files, it's mainly for creating new files
+  - name: Enable the RHEL6 server optional RPMs repo
+    ini_file:
+      path: /etc/yum.repos.d/redhat-rhui.repo
+      section: rhui-REGION-rhel-server-releases-optional
+      option: enabled
+      value: yes
+      create: no
+      state: present
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "6"
+
   # RHEL7 optional RPMs are required for yum-cron and -devel packages
   # we can't use yum_repository ansible module because it doesn't allow
   # modification of existing repo files, it's mainly for creating new files

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -1,5 +1,6 @@
 ---
 - hosts:
+  - worker_rhel6
   - worker_rhel7
   - worker_fedora
 

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -76,6 +76,13 @@
       - chkconfig
       state: installed
 
+  - name: Ensure procps is installed (OpenSCAP dependency)
+    package:
+      name:
+      - procps
+      state: installed
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] <= "6"
+
   - name: Ensure procps-ng is installed (OpenSCAP dependency)
     package:
       name:


### PR DESCRIPTION
rhel6 node is here to stay.

Revert commits that dropped it from inventory, and removed its exclusive configuration task.