### PR TITLE
Add openscap-python to OAA dependencies

### DIFF
--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -187,6 +187,7 @@
   - name: Ensure OSCAP Anaconda dependencies are installed (RHEL7 only)
     package:
       name:
+      - openscap-python
       - anaconda
       - python2-mock
       - python-nose


### PR DESCRIPTION
OpenSCAP Python bindings are required to run OSCAP Anaconda Addon tests.
This affects RHEL7 Jenkins node.