### PR TITLE
Disable multiple jobs when running openscap ctest on master branch.

### DIFF
--- a/ansible/jobs/openscap-master.xml
+++ b/ansible/jobs/openscap-master.xml
@@ -64,8 +64,7 @@
     <hudson.plugins.cmake.CToolBuilder plugin="cmakebuilder@2.6.0">
       <installationName>InSearchPath</installationName>
       <workingDir>build</workingDir>
-      <toolArgs>-j $CPU_COUNT
---output-on-failure</toolArgs>
+      <toolArgs>--output-on-failure</toolArgs>
       <toolId>ctest</toolId>
     </hudson.plugins.cmake.CToolBuilder>
     <hudson.tasks.Shell>


### PR DESCRIPTION
There are some known concurrency issues with openscap tests and this PR disable running multiple jobs when testing the branch master.