### PR TITLE
Remove RHEL7 check of oscap 1.3

### DIFF
--- a/ansible/jobs/openscap-pull-requests-multi.xml
+++ b/ansible/jobs/openscap-pull-requests-multi.xml
@@ -146,7 +146,6 @@ yuumasato rsprudencio GautamSatish dahaic Hexadorsimal matusmarhefka kjankov jlc
       <name>label</name>
       <values>
         <string>fedora</string>
-        <string>rhel7</string>
         <string>rhel8</string>
       </values>
     </hudson.matrix.LabelAxis>


### PR DESCRIPTION
As oscap of 1.3 branch is not shipped on RHEL7, we can't commit to fix bugs that a RHEL7 test may uncover and that are not relevant for RHEL8 or Fedora.