### PR TITLE
Jenkins jobs configuration back up

### DIFF
--- a/ansible/jobs/content-test-filtering-pr.xml
+++ b/ansible/jobs/content-test-filtering-pr.xml
@@ -70,7 +70,7 @@ ggbecker</adminlist>
       <onlyTriggerPhrase>false</onlyTriggerPhrase>
       <useGitHubHooks>true</useGitHubHooks>
       <permitAll>false</permitAll>
-      <whitelist> rchayes iokomin matusmarhefka tedbrunell mildass aghassemlouei ggbecker lkinser jgwl maltek comps keithkjackson adelton justin-stephenson mildas vojtapolasek evgenyz 70k10 shaneboulden abergmann DominiqueDevinci nkinder mralph-rh jcpunk jhrozek redhat-rmcallis isimluk pschneiders Scronkfinkle konstruktoid JAORMX mrogers950 cyarbrough76 eradot4027 Klaas- pekramp</whitelist>
+      <whitelist> rchayes iokomin matusmarhefka tedbrunell mildass aghassemlouei ggbecker lkinser jgwl maltek comps keithkjackson adelton justin-stephenson mildas vojtapolasek evgenyz 70k10 shaneboulden abergmann DominiqueDevinci nkinder mralph-rh jcpunk jhrozek redhat-rmcallis isimluk pschneiders Scronkfinkle konstruktoid JAORMX mrogers950 cyarbrough76 eradot4027 Klaas- pekramp npoyant anixon-rh crleekwc</whitelist>
       <autoCloseFailedPullRequests>false</autoCloseFailedPullRequests>
       <displayBuildErrorsOnDownstreamBuilds>false</displayBuildErrorsOnDownstreamBuilds>
       <whiteListTargetBranches>

--- a/ansible/jobs/scap-security-guide-pull-requests.xml
+++ b/ansible/jobs/scap-security-guide-pull-requests.xml
@@ -83,7 +83,7 @@ ggbecker</adminlist>
       <onlyTriggerPhrase>false</onlyTriggerPhrase>
       <useGitHubHooks>true</useGitHubHooks>
       <permitAll>false</permitAll>
-      <whitelist> rchayes iokomin matusmarhefka tedbrunell mildass aghassemlouei ggbecker lkinser jgwl maltek comps keithkjackson adelton justin-stephenson mildas vojtapolasek evgenyz 70k10 shaneboulden abergmann DominiqueDevinci nkinder mralph-rh jcpunk jhrozek redhat-rmcallis isimluk pschneiders Scronkfinkle konstruktoid JAORMX mrogers950 cyarbrough76 eradot4027 Klaas- pekramp</whitelist>
+      <whitelist> rchayes iokomin matusmarhefka tedbrunell mildass aghassemlouei ggbecker lkinser jgwl maltek comps keithkjackson adelton justin-stephenson mildas vojtapolasek evgenyz 70k10 shaneboulden abergmann DominiqueDevinci nkinder mralph-rh jcpunk jhrozek redhat-rmcallis isimluk pschneiders Scronkfinkle konstruktoid JAORMX mrogers950 cyarbrough76 eradot4027 Klaas- pekramp npoyant anixon-rh crleekwc</whitelist>
       <autoCloseFailedPullRequests>false</autoCloseFailedPullRequests>
       <displayBuildErrorsOnDownstreamBuilds>false</displayBuildErrorsOnDownstreamBuilds>
       <whiteListTargetBranches>

--- a/ansible/jobs/scap-security-guide-scapval-scap-1.2.xml
+++ b/ansible/jobs/scap-security-guide-scapval-scap-1.2.xml
@@ -80,6 +80,9 @@
     <hudson.tasks.Shell>
       <command>$WORKSPACE/tests/run_scapval.py --scap-version 1.2 --scapval-path /opt/scapval/scapval-1.3.2.jar --build-dir $WORKSPACE/build</command>
     </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>rm -rf $WORKSPACE/build</command>
+    </hudson.tasks.Shell>
   </builders>
   <publishers/>
   <buildWrappers/>

--- a/ansible/jobs/scap-security-guide-scapval-scap-1.3.xml
+++ b/ansible/jobs/scap-security-guide-scapval-scap-1.3.xml
@@ -79,6 +79,9 @@
     <hudson.tasks.Shell>
       <command>$WORKSPACE/tests/run_scapval.py --scap-version 1.3 --scapval-path /opt/scapval/scapval-1.3.2.jar --build-dir $WORKSPACE/build</command>
     </hudson.tasks.Shell>
+    <hudson.tasks.Shell>
+      <command>rm -rf $WORKSPACE/build</command>
+    </hudson.tasks.Shell>
   </builders>
   <publishers/>
   <buildWrappers/>


### PR DESCRIPTION
Clean the build directory in SCAPVal jobs after they finish.
The built files take a lot of disk space and they don't have
to be kept.

Also, this patch backs up the contributors white list.