### PR TITLE
Update the configuration to set up temporary agents

### DIFF
--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,18 +1,28 @@
 [master]
-# jenkins-master ansible_host=13.58.12.8 ansible_user=ec2-user
 jenkins-master ansible_host=89.221.216.197 ansible_user=openscap-admin
 
 [worker_rhel6]
 jenkins-worker-rhel6-1 ansible_host=89.221.216.211 ansible_user=openscap-admin
+jenkins-worker-rhel6-2 ansible_host=complianceascode-jenkins-rhel6-01.redhatgov.io ansible_user=ec2-user
+jenkins-worker-rhel6-3 ansible_host=complianceascode-jenkins-rhel6-02.redhatgov.io ansible_user=ec2-user
+jenkins-worker-rhel6-4 ansible_host=complianceascode-jenkins-rhel6-03.redhatgov.io ansible_user=ec2-user
 
 [worker_rhel7]
 jenkins-worker-rhel7-1 ansible_host=89.221.216.210 ansible_user=openscap-admin
+jenkins-worker-rhel7-2 ansible_host=complianceascode-jenkins-rhel7-01.redhatgov.io ansible_user=ec2-user
+jenkins-worker-rhel7-3 ansible_host=complianceascode-jenkins-rhel7-02.redhatgov.io ansible_user=ec2-user
+jenkins-worker-rhel7-4 ansible_host=complianceascode-jenkins-rhel7-03.redhatgov.io ansible_user=ec2-user
 
 [worker_rhel8]
 jenkins-worker-rhel8-1 ansible_host=89.221.217.14 ansible_user=openscap-admin ansible_python_interpreter=/usr/bin/python3
+jenkins-worker-rhel8-2 ansible_host=complianceascode-jenkins-rhel8-01.redhatgov.io ansible_user=ec2-user
+jenkins-worker-rhel8-3 ansible_host=complianceascode-jenkins-rhel8-02.redhatgov.io ansible_user=ec2-user
 
 [worker_fedora]
 jenkins-worker-fedora-1 ansible_host=89.221.216.149 ansible_user=openscap-admin
+jenkins-worker-fedora-2 ansible_host=complianceascode-jenkins-f31-01.redhatgov.io ansible_user=fedora
+jenkins-worker-fedora-3 ansible_host=complianceascode-jenkins-f31-02.redhatgov.io ansible_user=fedora
+jenkins-worker-fedora-4 ansible_host=complianceascode-jenkins-f31-03.redhatgov.io ansible_user=fedora
 
 [all:vars]
 ansible_connection=ssh

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,28 +1,28 @@
 [master]
-jenkins-master ansible_host=89.221.216.197 ansible_user=openscap-admin
+jenkins-master ansible_host=89.221.216.197 ansible_user=openscap-admin provider=wedos
 
 [worker_rhel6]
-jenkins-worker-rhel6-1 ansible_host=89.221.216.211 ansible_user=openscap-admin
-jenkins-worker-rhel6-2 ansible_host=complianceascode-jenkins-rhel6-01.redhatgov.io ansible_user=ec2-user
-jenkins-worker-rhel6-3 ansible_host=complianceascode-jenkins-rhel6-02.redhatgov.io ansible_user=ec2-user
-jenkins-worker-rhel6-4 ansible_host=complianceascode-jenkins-rhel6-03.redhatgov.io ansible_user=ec2-user
+jenkins-worker-rhel6-1 ansible_host=89.221.216.211 ansible_user=openscap-admin provider=wedos
+jenkins-worker-rhel6-2 ansible_host=complianceascode-jenkins-rhel6-01.redhatgov.io ansible_user=ec2-user provider=amazon
+jenkins-worker-rhel6-3 ansible_host=complianceascode-jenkins-rhel6-02.redhatgov.io ansible_user=ec2-user provider=amazon
+jenkins-worker-rhel6-4 ansible_host=complianceascode-jenkins-rhel6-03.redhatgov.io ansible_user=ec2-user provider=amazon
 
 [worker_rhel7]
-jenkins-worker-rhel7-1 ansible_host=89.221.216.210 ansible_user=openscap-admin
-jenkins-worker-rhel7-2 ansible_host=complianceascode-jenkins-rhel7-01.redhatgov.io ansible_user=ec2-user
-jenkins-worker-rhel7-3 ansible_host=complianceascode-jenkins-rhel7-02.redhatgov.io ansible_user=ec2-user
-jenkins-worker-rhel7-4 ansible_host=complianceascode-jenkins-rhel7-03.redhatgov.io ansible_user=ec2-user
+jenkins-worker-rhel7-1 ansible_host=89.221.216.210 ansible_user=openscap-admin provider=wedos
+jenkins-worker-rhel7-2 ansible_host=complianceascode-jenkins-rhel7-01.redhatgov.io ansible_user=ec2-user provider=amazon
+jenkins-worker-rhel7-3 ansible_host=complianceascode-jenkins-rhel7-02.redhatgov.io ansible_user=ec2-user provider=amazon
+jenkins-worker-rhel7-4 ansible_host=complianceascode-jenkins-rhel7-03.redhatgov.io ansible_user=ec2-user provider=amazon
 
 [worker_rhel8]
-jenkins-worker-rhel8-1 ansible_host=89.221.217.14 ansible_user=openscap-admin ansible_python_interpreter=/usr/bin/python3
-jenkins-worker-rhel8-2 ansible_host=complianceascode-jenkins-rhel8-01.redhatgov.io ansible_user=ec2-user
-jenkins-worker-rhel8-3 ansible_host=complianceascode-jenkins-rhel8-02.redhatgov.io ansible_user=ec2-user
+jenkins-worker-rhel8-1 ansible_host=89.221.217.14 ansible_user=openscap-admin provider=wedos
+jenkins-worker-rhel8-2 ansible_host=complianceascode-jenkins-rhel8-01.redhatgov.io ansible_user=ec2-user provider=amazon
+jenkins-worker-rhel8-3 ansible_host=complianceascode-jenkins-rhel8-02.redhatgov.io ansible_user=ec2-user provider=amazon
 
 [worker_fedora]
-jenkins-worker-fedora-1 ansible_host=89.221.216.149 ansible_user=openscap-admin
-jenkins-worker-fedora-2 ansible_host=complianceascode-jenkins-f31-01.redhatgov.io ansible_user=fedora
-jenkins-worker-fedora-3 ansible_host=complianceascode-jenkins-f31-02.redhatgov.io ansible_user=fedora
-jenkins-worker-fedora-4 ansible_host=complianceascode-jenkins-f31-03.redhatgov.io ansible_user=fedora
+jenkins-worker-fedora-1 ansible_host=89.221.216.149 ansible_user=openscap-admin provider=wedos
+jenkins-worker-fedora-2 ansible_host=complianceascode-jenkins-f31-01.redhatgov.io ansible_user=fedora provider=amazon
+jenkins-worker-fedora-3 ansible_host=complianceascode-jenkins-f31-02.redhatgov.io ansible_user=fedora provider=amazon
+jenkins-worker-fedora-4 ansible_host=complianceascode-jenkins-f31-03.redhatgov.io ansible_user=fedora provider=amazon
 
 [all:vars]
 ansible_connection=ssh

--- a/ansible/shared.yml
+++ b/ansible/shared.yml
@@ -71,23 +71,6 @@
       enabled: yes
       state: started
 
-# despite being called yum-cron this works on RHEL and Fedora
-  - name: Install yum-cron
-    package:
-      name: yum-cron
-      state: present
-
-  - name: Copy yum-cron.conf over
-    copy:
-      src: shared_cfg/yum-cron.conf
-      dest: /etc/yum/yum-cron.conf
-
-  - name: Enable yum-cron service
-    service:
-      name: yum-cron
-      enabled: yes
-      state: started
-
   - name: Install tuned (performance tuning)
     package:
       name: tuned
@@ -122,6 +105,49 @@
       regexp: "^#?PasswordAuthentication"
       line: "PasswordAuthentication no"
     notify: restart sshd
+
+  - name: Install dnf-automatic package
+    package:
+      name: dnf-automatic
+      state: installed
+    when: ansible_facts['distribution'] == "Fedora" or (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] >= "8")
+
+  - name: Apply updates when they are available
+    ini_file:
+      path: /etc/dnf/automatic.conf
+      section: commands
+      option: apply_updates
+      value: 'yes'
+    when: ansible_facts['distribution'] == "Fedora" or (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] >= "8")
+
+  - name: Enable dnf-automatic timer
+    service:
+      name: dnf-automatic.timer
+      state: started
+      enabled: yes
+    when: ansible_facts['distribution'] == "Fedora" or (ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] >= "8")
+
+  tasks:
+  - name: Install yum-cron package
+    package:
+      name: yum-cron
+      state: installed
+    when: ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] <= "7"
+
+  - name: Apply updates when they are available
+    ini_file:
+      path: /etc/yum/yum-cron.conf
+      section: commands
+      option: apply_updates
+      value: 'yes'
+    when: ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] <= "7"
+
+  - name: Enable yum-cron service
+    service:
+      name: yum-cron
+      state: started
+      enabled: yes
+    when: ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version'] <= "7"
 
   handlers:
   - name: restart sshd

--- a/ansible/shared.yml
+++ b/ansible/shared.yml
@@ -41,32 +41,6 @@
       gpgcheck: yes
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "6"
 
-  # RHEL6 optional RPMs are required for yum-cron and -devel packages
-  # we can't use yum_repository ansible module because it doesn't allow
-  # modification of existing repo files, it's mainly for creating new files
-  - name: Enable the RHEL6 server optional RPMs repo
-    ini_file:
-      path: /etc/yum.repos.d/redhat-rhui.repo
-      section: rhui-REGION-rhel-server-releases-optional
-      option: enabled
-      value: yes
-      create: no
-      state: present
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "6"
-
-  # RHEL7 optional RPMs are required for yum-cron and -devel packages
-  # we can't use yum_repository ansible module because it doesn't allow
-  # modification of existing repo files, it's mainly for creating new files
-  - name: Enable the RHEL7 server optional RPMs repo
-    ini_file:
-      path: /etc/yum.repos.d/redhat-rhui.repo
-      section: rhui-REGION-rhel-server-optional
-      option: enabled
-      value: yes
-      create: no
-      state: present
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
-
   - name: Install pip
     package:
       name:

--- a/ansible/shared.yml
+++ b/ansible/shared.yml
@@ -72,6 +72,14 @@
       name:
       - python-pip
       state: installed
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] <= "7"
+
+  - name: Install pip3
+    package:
+      name:
+      - python3-pip
+      state: installed
+    when: ansible_distribution != 'RedHat' or ansible_distribution_version.split(".")[0] >= "8"
 
   - name: Install cronie
     package:

--- a/ansible/shared.yml
+++ b/ansible/shared.yml
@@ -5,6 +5,11 @@
   become_method: sudo
 
   tasks:
+  - name: upgrade all packages
+    yum:
+      name: '*'
+      state: latest
+
   - name: Set hostname
     hostname:
       name: "{{ inventory_hostname }}"

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -325,7 +325,7 @@
   - name: Ensure Zanata is installed (Fedora only)
     package:
       name:
-      - zanata-python-client
+      - python3-zanata-client
       state: installed
     when: ansible_distribution == 'Fedora'
 

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -256,14 +256,14 @@
     pip:
       name:
       - git+https://github.com/linkcheck/linkchecker.git
-    when: ansible_distribution != 'RedHat' or ansible_distribution_version.split(".")[0] != "6"
+    when: ansible_distribution != 'RedHat' or ansible_distribution_version.split(".")[0] == "8"
 
-  # RHEL may not have pytest
-  - name: Ensure pytest coverage support is installed (RHEL only)
-    pip:
+  - name: Ensure pytest coverage support is installed (RHEL 7 only)
+    package:
       name:
       - pytest
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] >= "6"
+      state: installed
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
 
   - name: Ensure json2html is installed so it can convert profile statistics to HTML
     pip:

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -60,12 +60,33 @@
   - name: Add the Red Hat CodeReady Linux Builder for RHEL 8 x86_64
     rhsm_repository:
       name: codeready-builder-for-rhel-8-x86_64-rpms
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    when: provider != 'amazon' and ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+
+  - name: Add the Red Hat CodeReady Linux Builder for RHEL 8 x86_64 (Amazon systems)
+    ini_file:
+      path: /etc/yum.repos.d/redhat-rhui.repo
+      section: codeready-builder-for-rhel-8-rhui-rpms
+      option: enabled
+      value: '1'
+    when: provider == 'amazon' and ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+
+  - name: Add RHEL7 Server Optional repo
+    rhsm_repository:
+      name: rhel-7-server-optional-rpms
+    when: provider != 'amazon' and ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
+
+  - name: Add RHEL7 Server Optional repo (Amazon systems)
+    ini_file:
+      path: /etc/yum.repos.d/redhat-rhui.repo
+      section: rhel-7-server-rhui-optional-rpms
+      option: enabled
+      value: '1'
+    when: provider == 'amazon' and ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
 
   - name: Add the Red Hat Ansible Engine 2 for RHEL 8 x86_64
     rhsm_repository:
       name: ansible-2-for-rhel-8-x86_64-rpms
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    when: provider != 'amazon' and ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
 
   - name: Ensure general build dependencies are installed
     package:

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -14,17 +14,17 @@
       name: jenkins
       comment: "Jenkins user"
 
-  - name: Install prerequisites for authorized keys addition (except RHEL8)
+  - name: Install prerequisites for authorized keys addition (RHEL6, RHEL7)
     package:
       name:
       - libselinux-python
-    when: (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] != "8") or ansible_distribution == 'Fedora'
+    when: ansible_distribution == 'RedHat' and (ansible_distribution_version.split(".")[0] == "6" or ansible_distribution_version.split(".")[0] == "7")
 
-  - name: Install prerequisites for authorized keys addition (RHEL8 only)
+  - name: Install prerequisites for authorized keys addition (RHEL8, Fedora)
     package:
       name:
       - python3-libselinux
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    when: (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8") or ansible_distribution == 'Fedora'
 
   # we use the public key to connect to slaves from jenkins master
   - name: Authorize master's jenkins user public key

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -256,13 +256,14 @@
     pip:
       name:
       - git+https://github.com/linkcheck/linkchecker.git
+    when: ansible_distribution != 'RedHat' or ansible_distribution_version.split(".")[0] != "6"
 
   # RHEL may not have pytest
   - name: Ensure pytest coverage support is installed (RHEL only)
     pip:
       name:
       - pytest
-    when: ansible_distribution == 'RedHat'
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] >= "6"
 
   - name: Ensure json2html is installed so it can convert profile statistics to HTML
     pip:

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -134,19 +134,19 @@
       - libyaml-devel
       state: installed
 
-  - name: Ensure OpenSCAP dependencies are installed (Except RHEL8)
+  - name: Ensure OpenSCAP dependencies are installed (RHEL6, RHEL7)
     package:
       name:
       - python-devel
       state: installed
-    when: ansible_distribution != 'RedHat' or ansible_distribution_version.split(".")[0] != "8"
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] <= "7"
 
-  - name: Ensure OpenSCAP dependencies are installed (RHEL8 only)
+  - name: Ensure OpenSCAP dependencies are installed (RHEL8, Fedora)
     package:
       name:
       - python3-devel
       state: installed
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    when: (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8") or ansible_distribution == 'Fedora'
 
   - name: Ensure procps is installed (OpenSCAP dependency) (RHEL6 only)
     package:
@@ -206,8 +206,6 @@
   - name: Ensure SCAP Security Guide dependencies are installed (Fedora only)
     package:
       name:
-      - python2-jinja2  # needed for the new SSG yaml/jinja2 port
-      - python2-pytest
       - python3-pytest  # needed for unit tests + coverage
       - python3-jinja2
       - python3-PyYAML
@@ -246,7 +244,6 @@
       - python3-pytest  # needed for unit tests + coverage
       - python3-jinja2
       - python3-PyYAML
-      - python3-pip
       state: installed
     when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
 

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -286,19 +286,7 @@
       state: installed
     when: ansible_distribution != 'RedHat' or ansible_distribution_version.split(".")[0] == "7"
 
-  - name: Ensure OpenSCAP Daemon extra dependencies are installed (Fedora only)
-    package:
-      name:
-      - python-gobject-base
-      - python-gobject
-      - python3-dbus
-      - pygobject3-devel
-      - python3-gobject-base
-      - python3-gobject
-      state: installed
-    when: ansible_distribution == 'Fedora'
-
-  - name: Ensure OpenSCAP Daemon extra dependencies are installed (RHEL8 only)
+  - name: Ensure OpenSCAP Daemon extra dependencies are installed (Fedora, RHEL8)
     package:
       name:
       - python3-dbus

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -303,7 +303,7 @@
       - gobject-introspection
       - pygobject2-devel
       state: installed
-    when: ansible_distribution != 'RedHat' or ansible_distribution_version.split(".")[0] == "7"
+    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "7"
 
   - name: Ensure OpenSCAP Daemon extra dependencies are installed (Fedora, RHEL8)
     package:

--- a/deployment.md
+++ b/deployment.md
@@ -36,6 +36,17 @@ In case of RHEL, enable the `rhel-7-server-extras-rpms` and `rhel-7-server-optio
 You might want to use Ansible Playbooks, saved in ```./ansible``` directory.
 Please see ```README.md``` for details.
 
+However, there can be issues that can cause the Ansible Playbooks to fail.
+
+* If you don't configure master but only a worker, you have to have the `jenkins` user public key ready on your laptop for the Playbooks to find it.  Copy the key from `/var/lib/jenkins/.ssh/id_rsa.pub` on master node and save it to `<your_git_folder>/jenkins/ansible/generated_bits/master_id_rsa.pub`.
+* If a new version of RHEL is released, you need to review the whole playbook, as some Ansible tasks are enabled only on a specific RHEL version and you might need to change the "when" statement of these tasks.
+* It is necessary to run `yum update` before applying the playbook. It's particularly important on Amazon, because AMIs are available only in major release versions. For example, when setting up RHEL 7, you will get RHEL 7.0 AMI. But RHEL 7.0 has old crypto libraries that will cause every download from the internet to fail, therefore the Playbook won't be able to install any package. Updating the system solves the problem.
+* RHEL Workers running in Amazon don't use normal subscription. You can't use subscription manager or Ansible tasks that use subscription manager. Instead, RHEL workers in Amazon use RHUI. You can install packages normally using yum/dnf without subscribing. However, the repositories have different names and different IDs. You can enable CRB or optional repos by editing `/etc/yum.repos.d/`, but you need to orient yourself by descriptions.
+* Fedora evolves quickly and the Playbooks can contain old or obsolete of packages that don't exist on the latest Fedora. Try to find their alternatives.
+* PIP on RHEL 6 fails to install the latest Python packages. Try to install the python packages packaged in distribution instead. Alternatively, modify the tests run in CI to skip the test cases that need these Python packages.
+
+If possible, please modify the Playbooks and submit a PR against this repository.
+
 ### Important files & paths on Jenkins master
  - **/var/lib/jenkins/**
 	- Complete configuration folder storage


### PR DESCRIPTION
We add new agents on inventory.

We have to do some changes for Fedora 31 as the Python 2 packages aren't there. I think that we will upgrade also the Fedora 30 node after Fedora 31 EOL so we don't need to keep the backwards compatibility of the playbooks.

We also forget to disable pytest for RHEL6 in Playbooks.

This PR also configures automatic updates to avoid updating 16 systems manually.

For more details please read commit messages of every commit.
