### PR TITLE
Add content-test-filtering dependencies to playbook

### DIFF
--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -277,6 +277,14 @@
       - yamllint
     when: ansible_distribution != 'RedHat' or ansible_distribution_version.split(".")[0] >= "7"
 
+  - name: Ensure content-test-filtering dependencies are installed
+    pip:
+      name:
+      - gitpython
+      - xmldiff
+      - deepdiff
+    when: ansible_distribution == 'Fedora'
+
   - name: Ensure OpenSCAP Daemon dependencies are installed (RHEL7 only)
     package:
       name:


### PR DESCRIPTION
Add dependencies installation with `pip` on Fedora worker.