### PR TITLE
Install strace

### DIFF
--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -165,6 +165,7 @@
   - name: Ensure OpenSCAP dependencies are installed (RHEL8, Fedora)
     package:
       name:
+      - strace
       - python3-devel
       state: installed
     when: (ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8") or ansible_distribution == 'Fedora'


### PR DESCRIPTION
The strace package is a new dependency of OpenSCAP upstream test suite
introduced by
https://github.com/OpenSCAP/openscap/pull/1534.
It's in maint-1.3 branch, so it will run only on RHEL 8 and Fedora.