### PR TITLE
Change job "OpenSCAP memory consumption"

### DIFF
--- a/ansible/jobs/openscap-maint-1.2-pull-requests-multi.xml
+++ b/ansible/jobs/openscap-maint-1.2-pull-requests-multi.xml
@@ -103,7 +103,7 @@ bushong1
 zemb                                                                            
 jokajak                                                                         
 radzy                                                                           
-yuumasato rsprudencio GautamSatish dahaic Hexadorsimal matusmarhefka kjankov jlcharton matejak JennyUWaterloo cipherboy abergmann mildass teselkin ggbecker iokomin evgenyz mildas ignatenkobrain vojtapolasek DominiqueDevinci JAORMX carlosmmatos</whitelist>
+yuumasato rsprudencio GautamSatish dahaic Hexadorsimal matusmarhefka kjankov jlcharton matejak JennyUWaterloo cipherboy abergmann mildass teselkin ggbecker iokomin evgenyz mildas ignatenkobrain vojtapolasek DominiqueDevinci JAORMX carlosmmatos Honny1</whitelist>
       <autoCloseFailedPullRequests>false</autoCloseFailedPullRequests>
       <displayBuildErrorsOnDownstreamBuilds>false</displayBuildErrorsOnDownstreamBuilds>
       <whiteListTargetBranches>

--- a/ansible/jobs/openscap-memory-consumption.xml
+++ b/ansible/jobs/openscap-memory-consumption.xml
@@ -41,7 +41,7 @@
       </hudson.plugins.git.extensions.impl.SubmoduleOption>
     </extensions>
   </scm>
-  <assignedNode>rhel8</assignedNode>
+  <assignedNode>rhel7 || rhel8</assignedNode>
   <canRoam>false</canRoam>
   <disabled>false</disabled>
   <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>

--- a/ansible/jobs/openscap-pull-requests-multi.xml
+++ b/ansible/jobs/openscap-pull-requests-multi.xml
@@ -112,7 +112,7 @@ bushong1
 zemb                                                                            
 jokajak                                                                         
 radzy                                                                           
-yuumasato rsprudencio GautamSatish dahaic Hexadorsimal matusmarhefka kjankov jlcharton matejak JennyUWaterloo cipherboy abergmann mildass teselkin ggbecker iokomin evgenyz mildas ignatenkobrain vojtapolasek DominiqueDevinci JAORMX carlosmmatos</whitelist>
+yuumasato rsprudencio GautamSatish dahaic Hexadorsimal matusmarhefka kjankov jlcharton matejak JennyUWaterloo cipherboy abergmann mildass teselkin ggbecker iokomin evgenyz mildas ignatenkobrain vojtapolasek DominiqueDevinci JAORMX carlosmmatos Honny1</whitelist>
       <autoCloseFailedPullRequests>false</autoCloseFailedPullRequests>
       <displayBuildErrorsOnDownstreamBuilds>false</displayBuildErrorsOnDownstreamBuilds>
       <whiteListTargetBranches>

--- a/ansible/jobs/scap-security-guide-pull-requests.xml
+++ b/ansible/jobs/scap-security-guide-pull-requests.xml
@@ -114,6 +114,7 @@ ggbecker</adminlist>
           <statusUrl></statusUrl>
           <addTestResults>false</addTestResults>
         </org.jenkinsci.plugins.ghprb.extensions.status.GhprbSimpleStatus>
+        <org.jenkinsci.plugins.ghprb.extensions.comments.GhprbBuildStatus/>
       </extensions>
     </org.jenkinsci.plugins.ghprb.GhprbTrigger>
   </triggers>

--- a/ansible/workers.yml
+++ b/ansible/workers.yml
@@ -385,9 +385,9 @@
       line: 'jenkins ALL=(ALL)       NOPASSWD: /sbin/setcap, /usr/bin/rm, /usr/bin/chmod, /usr/bin/chown, /usr/bin/cgcreate, /usr/bin/cgset, /usr/bin/cgdelete'
       validate: visudo -cf %s
 
-  - name: Install dependencies for openscap-memory-consumption Jenkins job (RHEL8 only)
+  - name: Install dependencies for openscap-memory-consumption Jenkins job (RHEL 7, 8 only)
     package:
       name:
       - libcgroup-tools
       state: installed
-    when: ansible_distribution == 'RedHat' and ansible_distribution_version.split(".")[0] == "8"
+    when: ansible_distribution == 'RedHat' and (ansible_distribution_version.split(".")[0] == "8" or ansible_distribution_version.split(".")[0] == "7")


### PR DESCRIPTION
This will enable us to run the openscap-memory-consumption job also on
RHEL 7 worker, not only on RHEL 8.

Also contains a backup of Jenkins configuration as of 2020-10-06.