### PR TITLE
Change openscap master and maint-1.3 build type to RelWithDebInfo

### DIFF
--- a/ansible/jobs/openscap-maint-1.3-valgrind-test.xml
+++ b/ansible/jobs/openscap-maint-1.3-valgrind-test.xml
@@ -60,7 +60,7 @@
       <toolArgs>-DENABLE_VALGRIND=ON</toolArgs>
       <generator>Ninja</generator>
       <sourceDir>.</sourceDir>
-      <buildType>Debug</buildType>
+      <buildType>RelWithDebInfo</buildType>
       <cleanBuild>true</cleanBuild>
       <toolSteps>
         <hudson.plugins.cmake.BuildToolStep>

--- a/ansible/jobs/openscap-maint-1.3.xml
+++ b/ansible/jobs/openscap-maint-1.3.xml
@@ -59,7 +59,7 @@
       <workingDir>build/</workingDir>
       <generator>Ninja</generator>
       <sourceDir>.</sourceDir>
-      <buildType>Debug</buildType>
+      <buildType>RelWithDebInfo</buildType>
       <cleanBuild>true</cleanBuild>
       <toolSteps>
         <hudson.plugins.cmake.BuildToolStep>

--- a/ansible/jobs/openscap-master-disabled-probes.xml
+++ b/ansible/jobs/openscap-master-disabled-probes.xml
@@ -47,7 +47,7 @@
       <installationName>InSearchPath</installationName>
       <workingDir>build/</workingDir>
       <toolArgs>-DENABLE_PROBES=FALSE</toolArgs>
-      <buildType>Debug</buildType>
+      <buildType>RelWithDebInfo</buildType>
       <cleanBuild>false</cleanBuild>
     </hudson.plugins.cmake.CmakeBuilder>
     <hudson.tasks.Shell>

--- a/ansible/jobs/openscap-master-pull-requests-multi.xml
+++ b/ansible/jobs/openscap-master-pull-requests-multi.xml
@@ -162,7 +162,7 @@ yuumasato rsprudencio GautamSatish dahaic Hexadorsimal matusmarhefka kjankov jlc
       <workingDir>build</workingDir>
       <generator>${BUILD_BACKEND}</generator>
       <sourceDir>.</sourceDir>
-      <buildType>Debug</buildType>
+      <buildType>RelWithDebInfo</buildType>
       <cleanBuild>true</cleanBuild>
       <toolSteps>
         <hudson.plugins.cmake.BuildToolStep>

--- a/ansible/jobs/openscap-master-pull-requests.xml
+++ b/ansible/jobs/openscap-master-pull-requests.xml
@@ -171,7 +171,7 @@ yuumasato rsprudencio GautamSatish dahaic Hexadorsimal matusmarhefka kjankov jlc
       <installationName>InSearchPath</installationName>
       <workingDir>build/</workingDir>
       <sourceDir>.</sourceDir>
-      <buildType>Debug</buildType>
+      <buildType>RelWithDebInfo</buildType>
       <cleanBuild>true</cleanBuild>
       <toolSteps>
         <hudson.plugins.cmake.BuildToolStep>

--- a/ansible/jobs/openscap-master.xml
+++ b/ansible/jobs/openscap-master.xml
@@ -51,7 +51,7 @@
       <workingDir>build/</workingDir>
       <generator>Ninja</generator>
       <sourceDir>.</sourceDir>
-      <buildType>Debug</buildType>
+      <buildType>RelWithDebInfo</buildType>
       <cleanBuild>true</cleanBuild>
       <toolSteps>
         <hudson.plugins.cmake.BuildToolStep>

--- a/ansible/jobs/openscap-memory-consumption.xml
+++ b/ansible/jobs/openscap-memory-consumption.xml
@@ -56,7 +56,7 @@
     <hudson.plugins.cmake.CmakeBuilder plugin="cmakebuilder@2.6.0">
       <installationName>InSearchPath</installationName>
       <workingDir>build</workingDir>
-      <buildType>Debug</buildType>
+      <buildType>RelWithDebInfo</buildType>
       <cleanBuild>true</cleanBuild>
       <toolSteps>
         <hudson.plugins.cmake.BuildToolStep>

--- a/ansible/jobs/openscap-pull-requests-multi.xml
+++ b/ansible/jobs/openscap-pull-requests-multi.xml
@@ -171,7 +171,7 @@ yuumasato rsprudencio GautamSatish dahaic Hexadorsimal matusmarhefka kjankov jlc
       <workingDir>build</workingDir>
       <generator>${BUILD_BACKEND}</generator>
       <sourceDir>.</sourceDir>
-      <buildType>Debug</buildType>
+      <buildType>RelWithDebInfo</buildType>
       <cleanBuild>true</cleanBuild>
       <toolSteps>
         <hudson.plugins.cmake.BuildToolStep>


### PR DESCRIPTION
Do not use `Debug` build type when testing openscap `maint-1.3`
and `master` branches as it produces a little bit different binaries
which can mask certain kind of issues (like some structures having
different sizes in memory) compared to `Release` or `RelWithDebInfo`
build types.